### PR TITLE
Disable UAC remote restrictions remotely

### DIFF
--- a/ResitryKeyDelete.ps1
+++ b/ResitryKeyDelete.ps1
@@ -1,0 +1,5 @@
+$servers = “New-IndusDirect-Web-W2K8",”CTFS-Meridian",”CFDINDUSLOAN","HHTFTP","PROGENIE"
+
+$credential = Get-Credential -Credential iblvaadmin
+
+Invoke-Command -ComputerName $servers -Credential $credential -ScriptBlock {Remove-Item -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system\LocalAccountTokenFilterPolicy}

--- a/ResitryKeyInsert.ps1
+++ b/ResitryKeyInsert.ps1
@@ -1,0 +1,5 @@
+$servers = “New-IndusDirect-Web-W2K8",”Meridian",”CFDINDUSLOAN","HHTFTP","PROGENIE"
+
+$credential = Get-Credential -Credential iblvaadmin
+
+Invoke-Command -ComputerName $servers -Credential $credential -ScriptBlock {New-Item -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\system -Name LocalAccountTokenFilterPolicy -Value “1”}


### PR DESCRIPTION
While doing Nessus scan on workgroup systems, I have noted an issue of UAC blocking nessus audit traffic from reading registry keys. ResitryKeyInsert.ps1 will add LocalAccountTokenFilterPolicy key inoder to disable UAC. After scanning, you can revert back (enable UAC) using the ResitryKeyDelete.ps1 powershell script. Note: Please test the scripts in a test environment before running.
